### PR TITLE
Add general yaml parsing rules and cleanup

### DIFF
--- a/docs/description/E0000.md
+++ b/docs/description/E0000.md
@@ -1,0 +1,3 @@
+Checks for Null values and Duplicate values in resources
+
+[SOURCE](https://github.com/awslabs/cfn-python-lint)

--- a/docs/description/E0001.md
+++ b/docs/description/E0001.md
@@ -1,0 +1,3 @@
+Errors found when performing transformation on the template
+
+[SOURCE](https://github.com/awslabs/cfn-python-lint)

--- a/docs/description/E0002.md
+++ b/docs/description/E0002.md
@@ -1,0 +1,3 @@
+Errors found when processing a rule on the template
+
+[SOURCE](https://github.com/awslabs/cfn-python-lint)

--- a/docs/description/description.json
+++ b/docs/description/description.json
@@ -586,5 +586,23 @@
         "patternId": "E4001",
         "timeToFix": 5,
         "title": "Metadata Interface have appropriate properties"
+    },
+    {
+        "description": "Parse Lint Rule",
+        "patternId": "E0000",
+        "timeToFix": 5,
+        "title": "Parsing error found when parsing the template"
+    },
+    {
+        "description": "Transform Lint Rule",
+        "patternId": "E0001",
+        "timeToFix": 5,
+        "title": "Error found when transforming the template"
+    },
+    {
+        "description": "Rule processing Error",
+        "patternId": "E0002",
+        "timeToFix": 5,
+        "title": "Error processing rule on the template"
     }
 ]

--- a/docs/patterns.json
+++ b/docs/patterns.json
@@ -490,6 +490,21 @@
             "category": "ErrorProne",
             "level": "Error",
             "patternId": "E4001"
+        },
+        {
+            "category": "ErrorProne",
+            "level": "Error",
+            "patternId": "E0000"
+        },
+        {
+            "category": "ErrorProne",
+            "level": "Error",
+            "patternId": "E0001"
+        },
+        {
+            "category": "ErrorProne",
+            "level": "Error",
+            "patternId": "E0002"
         }
     ],
     "version": "0.8.3"

--- a/make_docs.py
+++ b/make_docs.py
@@ -24,7 +24,7 @@ import importlib.util
 # It further creates the ./docs folder and places everything in its right place.
 
 
-def get_class_instance(path, path_prefix):
+def get_class_instance(path, path_prefix, class_name=""):
     """Get and instantiate class contained in a given souce file
     
     :param path        : source file containing a class we wish to instantiate
@@ -35,13 +35,55 @@ def get_class_instance(path, path_prefix):
     spec = importlib.util.spec_from_file_location(module_name, path)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
-    class_name = module_name.split(".")[-1]
-    return getattr(module, class_name)
+
+    if not class_name:
+        return getattr(module, module_name.split(".")[-1])
+    else:
+        return getattr(module, class_name)
+
+def get_patterns(rule_class_instance):
+    """Extract patterns from a rule class instance
+
+    :param rule_class_instance : rule class instance from where to extract patterns
+    :return                    : dictionary with Codacy patterns info
+    """
+    level_map = dict(W="Warning", E="Error", I="Info")
+    category_map = dict(W="CodeStyle", E="ErrorProne", I="Documentation")
+
+    return dict(patternId=rule_class_instance.id,
+                level=level_map[rule_class_instance.id[0]],
+                category=category_map[rule_class_instance.id[0]])
+
+def get_docs(rule_class_instance):
+    """Extract documents from a rule class instance
+
+    :param rule_class_instance : rule class instance from where to extract documents
+    :return                    : dictionary with Codacy documents info
+    """
+    return dict(patternId=rule_class_instance.id,
+                title=rule_class_instance.shortdesc,
+                description=rule_class_instance.__doc__,
+                timeToFix=5)
+
+def write_description(desc_path, rule_class_instance):
+    """Write rule description file
+
+    :param desc_path           : path where to place description files
+    :param rule_class_instance : rule class instance from where to extract info
+    """
+    desc_file = open("%s/%s.md"%(desc_path, rule_class_instance.id), 'w')
+    desc_file.write("%s\n\n[SOURCE](%s)"%(rule_class_instance.description, rule_class_instance.source_url))
 
 
-def get_cfnlint_version(path):
-    vline = list(filter(lambda x: "__version__" in x, open(path, "r").readlines()))[0]
+def get_cfnlint_version(version_file):
+    """Get cfn-lint version
+
+    :param  version_file : file from where to extract version
+    :return              : version number
+    """
+    vline = list(filter(lambda x: "__version__" in x, open(version_file, "r").readlines()))[0]
     return vline.split("=")[1].strip().replace("'","")
+
 
 
 if len(sys.argv) != 2:
@@ -50,7 +92,9 @@ if len(sys.argv) != 2:
 else:
     cfnlint_path = sys.argv[1]
 
+
 os.makedirs("./docs/description", mode=0o755)
+
 
 desc_file = open('./docs/tool-description.md', 'w')
 desc_file.write("CloudFormation Linter is a tool to validate CloudFormation yaml/json")
@@ -61,28 +105,32 @@ desc_file.write(" [Learn more](https://github.com/awslabs/cfn-python-lint)")
 docs = list()
 pats = dict(name="cfn-lint", version=get_cfnlint_version("%s/src/cfnlint/version.py"%cfnlint_path), patterns=list())
 
-LEVEL_MAP = dict(W="Warning", E="Error", I="Info")
-CATEGORY_MAP = dict(W="CodeStyle", E="ErrorProne", I="Documentation")
-
+# Parse general rules
 for path in glob.iglob("%s/src/cfnlint/rules/**/*.py"%cfnlint_path, recursive=True):
 
     if path.split('/')[-1] == "__init__.py":
         continue
-
     print(path)
     rule_class = get_class_instance(path, "%s/src/"%cfnlint_path)
+    pats['patterns'].append(get_patterns(rule_class))
+    docs.append(get_docs(rule_class))
+    write_description("./docs/description", rule_class)
 
-    pats['patterns'].append(dict(patternId=rule_class.id,
-                                 level=LEVEL_MAP[rule_class.id[0]],
-                                 category=CATEGORY_MAP[rule_class.id[0]]))
+# Special case for yaml general errors
+parse_error_class = get_class_instance("%s/src/cfnlint/__init__.py"%cfnlint_path, "%s/src/"%cfnlint_path, "ParseError")
+pats['patterns'].append(get_patterns(parse_error_class))
+docs.append(get_docs(parse_error_class))
+write_description("./docs/description", parse_error_class)
 
-    docs.append(dict(patternId=rule_class.id,
-                     title=rule_class.shortdesc,
-                     description=rule_class.__doc__,
-                     timeToFix=5))
+transform_error_class = get_class_instance("%s/src/cfnlint/__init__.py"%cfnlint_path, "%s/src/"%cfnlint_path, "TransformError")
+pats['patterns'].append(get_patterns(transform_error_class))
+docs.append(get_docs(transform_error_class))
+write_description("./docs/description", transform_error_class)
 
-    rule_file = open("./docs/description/%s.md"%rule_class.id, 'w')
-    rule_file.write("%s\n\n[SOURCE](%s)"%(rule_class.description, rule_class.source_url))
+rule_error_class = get_class_instance("%s/src/cfnlint/__init__.py"%cfnlint_path, "%s/src/"%cfnlint_path, "RuleError")
+pats['patterns'].append(get_patterns(rule_error_class))
+docs.append(get_docs(rule_error_class))
+write_description("./docs/description", rule_error_class)
 
 pats_file = open('./docs/patterns.json', 'w')
 pats_file.write(json.dumps(pats, indent=4, sort_keys=True))


### PR DESCRIPTION
This PR removes the method checking if a file is a valid CloudFormation file, since Codacy will already supply a list of files for which the tool should be run.

A bit of cleanup was also preformed for `make_docs.py`. Since some things must be run on the general rule files and also for a few special cases it made sense to encapsulate them in functions.